### PR TITLE
Fixed a bug that permitted to calculate of a hash from an empty string

### DIFF
--- a/hashtheplanet/resources/git_resource.py
+++ b/hashtheplanet/resources/git_resource.py
@@ -91,6 +91,8 @@ class GitResource():
                     ['git', 'cat-file', '-p', blob_hash],
                     shell=False,
                 )
+                if len(file_content) == 0:
+                    continue
                 file_hash = self.get_hash(file_content)
                 files_info.append((file_path, tag_name, file_hash))
             except (ValueError, subprocess.CalledProcessError) as exception:


### PR DESCRIPTION
## Description

This pull request removes the possibility to calculate the hash of empty files.

## Related Issue(s)
 
N/A