### PR TITLE
Fixed the compilation of the lib, now hashtheplanet is the only namespace to access the lib

### DIFF
--- a/hashtheplanet/core/hashtheplanet.py
+++ b/hashtheplanet/core/hashtheplanet.py
@@ -15,10 +15,9 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 # project imports
-from resources.git_resource import GitResource
-from sql.db_connector import Base, DbConnector, Hash
+from hashtheplanet.resources.git_resource import GitResource
+from hashtheplanet.sql.db_connector import Base, DbConnector, Hash
 
-logger.remove()
 
 HASHTHEPLANET_VERSION = "HashThePlanet 0.0.0"
 
@@ -146,7 +145,7 @@ def main():
     The main function, which is the entry point of the program.
     It stores arguments provided by the user and launches hash computing.
     """
-
+    logger.remove()
     parser = argparse.ArgumentParser(description="HashThePlanet-0.0.0")
 
     parser.add_argument(

--- a/hashtheplanet/resources/git_resource.py
+++ b/hashtheplanet/resources/git_resource.py
@@ -17,7 +17,7 @@ from git.refs.tag import Tag
 from loguru import logger
 
 # project imports
-from sql.db_connector import DbConnector
+from hashtheplanet.sql.db_connector import DbConnector
 
 # types
 FilePath = str

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,8 +10,6 @@ classifiers =
 [options]
 python_requires = >=3.6
 packages = find:
-package_dir = 
-    =hashtheplanet
 install_requires =
     loguru>=0.5.3
     SQLAlchemy>=1.4.22
@@ -19,7 +17,8 @@ install_requires =
 
 [options.entry_points]
 console_scripts =
-    hashtheplanet = core.hashtheplanet:main
+    hashtheplanet = hashtheplanet.core.hashtheplanet:main
 
 [options.packages.find]
-where = hashtheplanet
+exclude =
+    tests

--- a/tests/core/test_hashtheplanet.py
+++ b/tests/core/test_hashtheplanet.py
@@ -3,9 +3,9 @@ from typing import Dict
 from unittest import mock
 from unittest.mock import MagicMock, mock_open, patch
 from loguru import logger
-from resources.git_resource import GitResource
+from hashtheplanet.resources.git_resource import GitResource
 
-from sql.db_connector import DbConnector, Hash
+from hashtheplanet.sql.db_connector import DbConnector, Hash
 from sqlalchemy.engine.base import Engine
 from sqlalchemy.orm.session import Session
 

--- a/tests/resources/test_git_resource.py
+++ b/tests/resources/test_git_resource.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 
 # project imports
 from hashtheplanet.resources.git_resource import BlobHash, FilePath, GitResource
-from sql.db_connector import DbConnector
+from hashtheplanet.sql.db_connector import DbConnector
 
 # third party imports
 from git.exc import GitCommandError


### PR DESCRIPTION
## Description

Fixed the compilation of the lib, now hashtheplanet is the only namespace to access the lib.  
Before this pull request when the hashtheplanet was compiled and installed, every subfolder was a namespace to access the lib.  
Example:  
- `sql.db_connector`
- `resources.git_resource`
And now, the `hashtheplanet` namespace is the only one that can be used to access the lib.
Example:  
- `hashtheplanet.sql.db_connector`
- `hashtheplanet.resources.git_resources`
## Related Issue(s)
 
N/A
