### PR TITLE
Added get_version function to the library

### DIFF
--- a/hashtheplanet/core/hashtheplanet.py
+++ b/hashtheplanet/core/hashtheplanet.py
@@ -139,6 +139,12 @@ class HashThePlanet():
         with self.session_scope() as session:
             return self._database.get_static_files(session)
 
+    def get_versions(self, technology: str) -> List[str]:
+        """
+        Returns all stored versions for a technology
+        """
+        with self.session_scope() as session:
+            return self._database.get_versions(session, technology)
 
 def main():
     """

--- a/hashtheplanet/sql/db_connector.py
+++ b/hashtheplanet/sql/db_connector.py
@@ -10,6 +10,7 @@ from typing import List
 from loguru import logger
 from sqlalchemy import JSON, Column, Text, select, update
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
+from sqlalchemy.sql.sqltypes import Integer
 
 Base = declarative_base()
 
@@ -21,6 +22,7 @@ class Version(Base):
     def __tablename__(cls): # pylint: disable=no-self-argument
         return cls.__name__.lower()
 
+    rowid = Column(Integer)
     technology = Column(Text, nullable=False, primary_key=True)
     version = Column(Text, nullable=False, primary_key=True)
 
@@ -109,7 +111,7 @@ class DbConnector():
         """
         Returns all the versions related to technology.
         """
-        stmt = select(Version).filter_by(technology=technology)
+        stmt = select(Version.version).filter_by(technology=technology).order_by(Version.rowid.asc())
         versions = session.execute(stmt).scalars().all()
         return versions
 

--- a/tests/core/test_hashtheplanet.py
+++ b/tests/core/test_hashtheplanet.py
@@ -259,6 +259,18 @@ def test_get_static_files():
     static_files = htp.get_static_files()
     assert len(static_files) == 2
 
+def test_get_versions():
+    class MockDatabase():
+        def get_versions(self, session_scope, technology):
+            return ["1.2.3", "1.2.4"]
+    htp = HashThePlanet("output.txt", "foobar.txt")
+
+    htp.session_scope = MagicMock()
+    htp._database = MockDatabase()
+
+    static_files = htp.get_versions("jquery")
+    assert len(static_files) == 2
+
 def test_main():
     def return_magic_mock(*args):
         return MagicMock()

--- a/tests/sql/test_db_connector.py
+++ b/tests/sql/test_db_connector.py
@@ -85,8 +85,7 @@ def test_get_versions(dbsession):
     retrieved_versions = DbConnector.get_versions(dbsession, techno)
     assert len(retrieved_versions) == 2
     for idx, _ in enumerate(retrieved_versions):
-        assert retrieved_versions[idx].technology == techno
-        assert retrieved_versions[idx].version == versions[idx]
+        assert retrieved_versions[idx] == versions[idx]
 
 
 def test_insert_file(dbsession):


### PR DESCRIPTION
## Description

This pull request adds the get_versions function to the library that permits to retrieves all versions of a technology.  
This function is used by the module HashThePlanet on wapiti.  

## Related Issue(s)
 
N/A