### PR TITLE
Added a github action to release the HashThePlanet database everyday

### DIFF
--- a/.github/workflows/db-release.yml
+++ b/.github/workflows/db-release.yml
@@ -1,0 +1,71 @@
+# This workflow updates the database and creates a release of it everyday
+
+name: Release Workflow
+on:
+  schedule:
+  - cron: "0 0 * * *"
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/tech_list.csv'
+
+jobs:
+  db-release:
+    name: "Database Release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Install requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install --no-deps -r requirements.txt
+          pip install --no-deps .
+          pip install pylint pytest
+
+      - name: "Download the latest published database"
+        uses: "robinraju/release-downloader@v1.2"
+        continue-on-error: true
+        with:
+          repository: "Cyberwatch/HashThePlanet"
+          latest: true
+          fileName: "hashtheplanet.db"
+          tarBall: false
+          zipBall: false
+          out-file-path: "dist/"
+
+      - name: "Update the database"
+        run: |
+          hashtheplanet --input src/tech_list.csv --output dist/hashtheplanet.db
+
+      - name: "Publish the daily release with the tag: ${{ steps.date.outputs.date }}"
+        uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "${{ steps.date.outputs.date }}"
+          prerelease: false
+          title: "Database release: ${{ steps.date.outputs.date }}"
+          files: |
+            dist/hashtheplanet.db
+
+      - name: "Publish the daily release with the tag: latest"
+        uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          prerelease: false
+          title: "Database release: Latest"
+          files: |
+            dist/hashtheplanet.db


### PR DESCRIPTION
## Description

This pull request adds a new workflow to create/update and upload the HashThePlanet database.  
This workflow can be triggered in three different ways:
- manual trigger via the Github action section of the repository
- every day at midnight
- every time the file `tech_list.csv` is modified and pushed to `main`
  
At the end of the workflow, a new release will be created with the current date as tag name, and the latest tag will be updated.  
You can see an example of release on my fork: https://github.com/JulienTD/HashThePlanet


## Related Issue(s)
 
#8 