### PR TITLE
Corriger les workflows GitHub et la récupération des versions de paquets NPM

### DIFF
--- a/.github/workflows/db-release.yml
+++ b/.github/workflows/db-release.yml
@@ -27,12 +27,7 @@ jobs:
 
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
-
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
+        run: echo "date::$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Install requirements
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: "3.9"
+          python-version: "3.12"
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/hashtheplanet/resources/npm_resource.py
+++ b/hashtheplanet/resources/npm_resource.py
@@ -6,11 +6,11 @@ import re
 import tarfile
 import tempfile
 from typing import Dict, List, Set, Tuple
-import requests
+import json
 
 # third party imports
 from loguru import logger
-from bs4 import BeautifulSoup
+import requests
 
 # project imports
 from hashtheplanet.sql.db_connector import Hash
@@ -34,22 +34,8 @@ class NpmResource(Resource):
         """
         This method retrieves npm module versions.
         """
-        page = requests.get(f"https://www.npmjs.com/package/{npm_module_name}?activeTab=versions", timeout=10)
-        soup = BeautifulSoup(page.content, "html.parser")
-        versions = set()
-
-        table = soup.find('div', attrs={'id':'tabpanel-versions'})
-
-        table_body_version_elements = list(table.find_all())[0]
-
-        version_rows = table_body_version_elements.find_all("li")
-
-        for row in list(version_rows):
-            version = row.find("a")
-            if version is None:
-                continue
-            versions.add(version.get_text())
-        return versions
+        page = requests.get(f"https://registry.npmjs.org/{npm_module_name}", timeout=10)
+        return set(json.loads(page.content)["versions"])
 
     @staticmethod
     def save_tar_to_disk(file_path: str, npm_module_name: str, version: str):

--- a/tests/resources/test_npm_resource.py
+++ b/tests/resources/test_npm_resource.py
@@ -19,27 +19,12 @@ def test_retrieve_versions():
     class MockedPage():
         def __init__(self) -> None:
             self.content = """
-            <html>
-            <head><title></title></head>
-            <body>
-                <div id="tabpanel-versions">
-                    <div>
-                        <div></div>
-                        <h3></h3>
-                        <ul><li></li></ul>
-                        <ul>
-                            <li></li>
-                            <li><a>1.0.1</a></li>
-                            <li><a>1.0.2</a></li>
-                            <li><a>1.0.3</a></li>
-                        </ul>
-                    </div>
-                    <div></div>
-                </div>
-            </body></html>
+            {
+              "versions": ["1.0.1", "1.0.2", "1.0.3"]
+            }
             """
     def mocked_get_request(url: str, *args, **kwargs):
-        assert url == f"https://www.npmjs.com/package/{npm_module_name}?activeTab=versions"
+        assert url == f"https://registry.npmjs.org/{npm_module_name}"
         return MockedPage()
 
     with mock.patch("requests.get", MagicMock(side_effect=mocked_get_request)):


### PR DESCRIPTION
Depuis décembre dernier, la BDD n'est plus construite et les actions/workflows GitHub ne passent plus pour les raisons suivantes :
- La page web de NPM qui était parsée pour récupérer les versions des paquets a été modifiée
- La version `3.7` de Python [n'est plus disponible dans les actions GitHub](https://github.com/Cyberwatch/HashThePlanet/actions/runs/12614764203).

Dans cette MR, on fait donc les modifications suivantes :
- On utilise [l'API de NPM](https://registry.npmjs.org/jquery), plutôt que de parser une page HTML.
- On met à jour les versions Python testées pour retirer la `3.7` et inclure les nouvelles jusqu'à la `3.12`.
- On met à jour le `set-output` [déprécié ](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)dans le workflow GitHub.

@fwininger 