### PR TITLE
Fix SPIP upstream git repository url

### DIFF
--- a/src/tech_list.json
+++ b/src/tech_list.json
@@ -7,7 +7,7 @@
             "https://github.com/drupal/drupal.git",
             "https://github.com/magento/magento2.git",
             "https://github.com/joomla/joomla-cms.git",
-            "https://github.com/spip/spip.git",
+            "https://git.spip.net/spip/spip.git",
             "https://github.com/PrestaShop/PrestaShop.git"
         ]
     },


### PR DESCRIPTION
@fwininger 

The SPIP project has moved from `github.com` to `git.spip.net`